### PR TITLE
Fix form data encoding for Google Apps Script

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,11 +370,15 @@
             const dates = Array.from(selectedDates).join(', ');
             const status = document.getElementById('feedback-status');
             status.textContent = 'Отправка...';
-            const data = new FormData();
+            const data = new URLSearchParams();
             data.append('name', name);
             data.append('dates', dates);
             try {
-                const res = await fetch(scriptURL, { method: 'POST', body: data });
+                const res = await fetch(scriptURL, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: data
+                });
                 if (res.ok) {
                     status.textContent = 'Данные отправлены!';
                     selectedDates.clear();


### PR DESCRIPTION
## Summary
- encode feedback form data using URLSearchParams
- send `application/x-www-form-urlencoded` headers when posting to Google Apps Script

## Testing
- `curl -I https://script.google.com/macros/s/AKfycby7P2sM6d7aJT1CT3mctcYpG5P0reoHu-F16n5Mm1rSTD3gcBOH1Bx6YoY7MCBZiPezYQ/exec` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684713c8a2688333a41ef96eb43b2112