### PR TITLE
Ensure d20 cube stays positioned on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
         /* --- D20 Dice Styles --- */
         .d20-container {
             position: absolute;
-            top: 13%;
-            left: 49%;
+            top: 71%;
+            left: 45%;
             width: 85px; /* Adjust size as needed */
             height: 85px; /* Adjust size as needed */
             display: flex;

--- a/index.html
+++ b/index.html
@@ -121,7 +121,10 @@
 
         /* --- Шапка сайта --- */
         .site-header {
-            width: 100%; max-width: 500px; margin-bottom: 30px;
+            position: relative; /* Positioning context for the d20 dice */
+            width: 100%;
+            max-width: 500px;
+            margin-bottom: 30px;
         }
         .site-header > img {
             width: 100%; height: auto; border-radius: 10px; border: 3px solid #c8a45c;


### PR DESCRIPTION
## Summary
- add `position: relative` to `.site-header` so the cube is placed relative to the header image

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686420e87d408333afb59fbed9d547f0